### PR TITLE
Nd 229

### DIFF
--- a/src/build_juniper_payload.py
+++ b/src/build_juniper_payload.py
@@ -1,5 +1,6 @@
 import json
 
+
 class BuildPayload:
     def __init__(self,
                  data: list,
@@ -18,6 +19,26 @@ class BuildPayload:
     def get_site_payload(self):
         return self._site_payload
 
+    def _validate_data(self, data):
+        required_keys = [
+            'Site Name',
+            'Site Address',
+            'gps',
+            'country_code',
+            'time_zone',
+            'Enable GovWifi',
+            'Enable MoJWifi'
+        ]
+        missing_keys = []
+        for d in data:
+            for required_key in required_keys:
+                if required_key in d:
+                    pass
+                else:
+                    missing_keys.append(required_key)
+        if missing_keys != []:
+            raise ValueError("Missing the following keys {missing_keys}".format(missing_keys=missing_keys))
+
 
     def _check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(self, gov_wifi, moj_wifi, site_group_ids: dict):
         result = []
@@ -35,6 +56,7 @@ class BuildPayload:
             site_group_ids: dict,
             ap_versions: dict
     ):
+        self._validate_data(data)
         json_objects = []
         for d in data:
             site = {'name': d.get('Site Name', ''),
@@ -194,7 +216,7 @@ class BuildPayload:
                 site_setting["vars"]["site_specific_radius_wired_nacs_secret"] = d.get(
                     'Wired NACS Radius Key')
 
-            site_dict = {"site":site, "site_setting":site_setting}
+            site_dict = {"site": site, "site_setting": site_setting}
             json_objects.append(site_dict)
 
         return json_objects

--- a/src/build_juniper_payload.py
+++ b/src/build_juniper_payload.py
@@ -1,0 +1,199 @@
+import json
+
+class BuildPayload:
+    def __init__(self,
+                 data: dict,
+                 rf_template_id: str,
+                 network_template_id: str,
+                 site_group_ids: dict,
+                 ap_versions: dict):
+        self._site_payload = self._build_site_payload(
+            data,
+            rf_template_id,
+            network_template_id,
+            site_group_ids,
+            ap_versions
+        )
+
+    def get_site_payload(self):
+        return self._site_payload
+
+
+    def _check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(self, gov_wifi, moj_wifi, site_group_ids: dict):
+        result = []
+        if moj_wifi == 'TRUE':
+            result.append(site_group_ids['moj_wifi'])
+        if gov_wifi == 'TRUE':
+            result.append(site_group_ids['gov_wifi'])
+        return result
+
+    def _build_site_payload(
+            self,
+            data: dict,
+            rf_template_id: str,
+            network_template_id: str,
+            site_group_ids: dict,
+            ap_versions: dict
+    ):
+        json_objects = []
+        for d in data:
+            site = {'name': d.get('Site Name', ''),
+                    'address': d.get('Site Address', ''),
+                    "latlng": {"lat": d.get('gps', '')[0], "lng": d.get('gps', '')[1]},
+                    "country_code": d.get('country_code', ''),
+                    "rftemplate_id": rf_template_id,
+                    "networktemplate_id": network_template_id,
+                    "timezone": d.get('time_zone', ''),
+                    "sitegroup_ids": self._check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(
+                        gov_wifi=d.get('Enable GovWifi', ''),
+                        moj_wifi=d.get('Enable MoJWifi', ''),
+                        site_group_ids=json.loads(site_group_ids)
+                    ),
+                    }
+
+            site_setting = {
+
+                "auto_upgrade": {
+                    "enabled": True,
+                    "version": "custom",
+                    "time_of_day": "02:00",
+                    "custom_versions": ap_versions,
+                    "day_of_week": ""
+                },
+
+                "rogue": {
+                    "min_rssi": -80,
+                    "min_duration": 20,
+                    "enabled": True,
+                    "honeypot_enabled": True,
+                    "whitelisted_bssids": [
+                        ""
+                    ],
+                    "whitelisted_ssids": [
+                    ]
+                },
+
+                "persist_config_on_device": True,
+
+                "engagement": {
+                    "dwell_tags": {
+                        "passerby": "1-300",
+                        "bounce": "3600-14400",
+                        "engaged": "25200-36000",
+                        "stationed": "50400-86400"
+                    },
+                    "dwell_tag_names": {
+                        "passerby": "Below 5 Min (Passerby)",
+                        "bounce": "1-4 Hours",
+                        "engaged": "7-10 Hours",
+                        "stationed": "14-24 Hours"
+                    },
+                    "hours": {
+                        "sun": None,
+                        "mon": None,
+                        "tue": None,
+                        "wed": None,
+                        "thu": None,
+                        "fri": None,
+                        "sat": None
+                    }
+                },
+                "analytic": {
+                    "enabled": True
+                },
+
+                "rtsa": {
+                    "enabled": False,
+                    "track_asset": False,
+                    "app_waking": False
+                },
+                "led": {
+                    "enabled": True,
+                    "brightness": 255
+                },
+                "wifi": {
+                    "enabled": True,
+                    "locate_unconnected": True,
+                    "mesh_enabled": False,
+                    "mesh_allow_dfs": False
+                },
+
+                "switch_mgmt": {
+                    "use_mxedge_proxy": False,
+                    "mxedge_proxy_port": "2222"
+                },
+
+                "wootcloud": None,
+                "skyatp": {
+                    "enabled": None,
+                    "send_ip_mac_mapping": None
+                },
+
+                "mgmt": {
+                    "use_wxtunnel": False
+                },
+
+                "config_auto_revert": True,
+                "status_portal": {
+                    "enabled": False,
+                    "hostnames": [
+                        ""
+                    ]
+                },
+                "uplink_port_config": {
+                    "keep_wlans_up_if_down": True
+                },
+                "ssh_keys": [],
+                "wids": {},
+                "mxtunnel": {
+                    "enabled": False
+                },
+                "occupancy": {
+                    "min_duration": None,
+                    "clients_enabled": False,
+                    "sdkclients_enabled": False,
+                    "assets_enabled": False,
+                    "unconnected_clients_enabled": False
+                },
+                "public_zone_occupancy": {
+                    "enabled": False,
+                    "client_density_enabled": False,
+                    "rssi_zones_enabled": False
+                },
+                "zone_occupancy_alert": {
+                    "enabled": False,
+                    "threshold": 5,
+                    "email_notifiers": []
+                },
+                "gateway_mgmt": {
+                    "app_usage": False,
+                    "security_log_source_interface": "",
+                    "auto_signature_update": {
+                        "enable": True,
+                        "time_of_day": "02:00",
+                        "day_of_week": ""
+                    }
+                },
+                "tunterm_monitoring": [],
+                "tunterm_monitoring_disabled": True,
+                "ssr": {},
+
+                "vars": {
+                    "address": d.get('Site Address', ''),
+                    "site_name": d.get('Site Name', '')
+                }
+            }
+
+            if 'GovWifi Radius Key' in d:
+                site_setting["vars"]["site_specific_radius_govwifi_secret"] = d.get(
+                    'GovWifi Radius Key')
+                site_setting["rogue"]["whitelisted_ssids"] = [
+                    "GovWifi"
+                ]
+            if 'Wired NACS Radius Key' in d:
+                site_setting["vars"]["site_specific_radius_wired_nacs_secret"] = d.get(
+                    'Wired NACS Radius Key')
+
+            json_objects.append(site)
+            json_objects.append(site_setting)
+        return json_objects

--- a/src/build_juniper_payload.py
+++ b/src/build_juniper_payload.py
@@ -2,7 +2,7 @@ import json
 
 class BuildPayload:
     def __init__(self,
-                 data: dict,
+                 data: list,
                  rf_template_id: str,
                  network_template_id: str,
                  site_group_ids: dict,
@@ -29,7 +29,7 @@ class BuildPayload:
 
     def _build_site_payload(
             self,
-            data: dict,
+            data: list,
             rf_template_id: str,
             network_template_id: str,
             site_group_ids: dict,

--- a/src/build_juniper_payload.py
+++ b/src/build_juniper_payload.py
@@ -37,8 +37,8 @@ class BuildPayload:
                 else:
                     missing_keys.append(required_key)
         if missing_keys != []:
-            raise ValueError("Missing the following keys {missing_keys}".format(missing_keys=missing_keys))
-
+            raise ValueError("Missing the following keys {missing_keys}".format(
+                missing_keys=missing_keys))
 
     def _check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(self, gov_wifi, moj_wifi, site_group_ids: dict):
         result = []
@@ -70,8 +70,8 @@ class BuildPayload:
                         gov_wifi=d.get('Enable GovWifi', ''),
                         moj_wifi=d.get('Enable MoJWifi', ''),
                         site_group_ids=json.loads(site_group_ids)
-                    ),
-                    }
+            ),
+            }
 
             site_setting = {
 

--- a/src/build_juniper_payload.py
+++ b/src/build_juniper_payload.py
@@ -194,6 +194,7 @@ class BuildPayload:
                 site_setting["vars"]["site_specific_radius_wired_nacs_secret"] = d.get(
                     'Wired NACS Radius Key')
 
-            json_objects.append(site)
-            json_objects.append(site_setting)
+            site_dict = {"site":site, "site_setting":site_setting}
+            json_objects.append(site_dict)
+
         return json_objects

--- a/src/juniper.py
+++ b/src/juniper.py
@@ -1,30 +1,14 @@
-import os
-import json
 import requests
 import json
 import getpass
 import sys
 from datetime import datetime
+from build_juniper_payload import BuildPayload
 
 # Mist CRUD operations
 
 
 class Admin:
-
-    @staticmethod
-    def get_ap_versions():
-        # Get AP versions from environment variable
-        ap_versions_str = os.getenv('AP_VERSIONS', '{}')
-        try:
-            # Checking for valid AP versions
-            # Attempt to parse invalid JSON, should raise ValueError
-            if ap_versions_str == 'Invalid JSON':
-                raise ValueError('Invalid AP_VERSIONS')
-            else:
-                return json.loads(ap_versions_str)
-        except json.JSONDecodeError:
-            print("Error: AP_VERSIONS environment variable is not a valid JSON string.")
-            return {}
 
     def login_via_username_and_password(self, username):
         # If no username defined ask user
@@ -113,15 +97,6 @@ class Admin:
         return json.loads(response.text)
 
 
-def check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(gov_wifi, moj_wifi, site_group_ids: dict):
-    result = []
-    if moj_wifi == 'TRUE':
-        result.append(site_group_ids['moj_wifi'])
-    if gov_wifi == 'TRUE':
-        result.append(site_group_ids['gov_wifi'])
-    return result
-
-
 def warn_if_using_org_id_production(org_id):
     production_org_ids = [
         '3e824dd6-6b37-4cc7-90bb-97d744e91175',
@@ -140,200 +115,30 @@ def warn_if_using_org_id_production(org_id):
                 raise ValueError('Invalid input')
 
 
-def build_payload(
-        d,
-        rf_template_id,
-        network_template_id,
-        site_group_ids
-):
-    # Get AP versions from environment variable
-    ap_versions = Admin.get_ap_versions()
-
-    site = {'name': d.get('Site Name', ''),
-            'address': d.get('Site Address', ''),
-            "latlng": {"lat": d.get('gps', '')[0], "lng": d.get('gps', '')[1]},
-            "country_code": d.get('country_code', ''),
-            "rftemplate_id": rf_template_id,
-            "networktemplate_id": network_template_id,
-            "timezone": d.get('time_zone', ''),
-            "sitegroup_ids": check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(
-                gov_wifi=d.get('Enable GovWifi', ''),
-                moj_wifi=d.get('Enable MoJWifi', ''),
-                site_group_ids=json.loads(site_group_ids)
-    ),
-    }
-    # MOJ specific attributes
-    site_setting = {
-
-        "auto_upgrade": {
-            "enabled": True,
-            "version": "custom",
-            "time_of_day": "02:00",
-            "custom_versions": ap_versions,
-            "day_of_week": ""
-        },
-
-        "rogue": {
-            "min_rssi": -80,
-            "min_duration": 20,
-            "enabled": True,
-            "honeypot_enabled": True,
-            "whitelisted_bssids": [
-                ""
-            ],
-            "whitelisted_ssids": [
-            ]
-        },
-
-        "persist_config_on_device": True,
-
-        "engagement": {
-            "dwell_tags": {
-                "passerby": "1-300",
-                "bounce": "3600-14400",
-                "engaged": "25200-36000",
-                "stationed": "50400-86400"
-            },
-            "dwell_tag_names": {
-                "passerby": "Below 5 Min (Passerby)",
-                "bounce": "1-4 Hours",
-                "engaged": "7-10 Hours",
-                "stationed": "14-24 Hours"
-            },
-            "hours": {
-                "sun": None,
-                "mon": None,
-                "tue": None,
-                "wed": None,
-                "thu": None,
-                "fri": None,
-                "sat": None
-            }
-        },
-        "analytic": {
-            "enabled": True
-        },
-
-        "rtsa": {
-            "enabled": False,
-            "track_asset": False,
-            "app_waking": False
-        },
-        "led": {
-            "enabled": True,
-            "brightness": 255
-        },
-        "wifi": {
-            "enabled": True,
-            "locate_unconnected": True,
-            "mesh_enabled": False,
-            "mesh_allow_dfs": False
-        },
-
-        "switch_mgmt": {
-            "use_mxedge_proxy": False,
-            "mxedge_proxy_port": "2222"
-        },
-
-        "wootcloud": None,
-        "skyatp": {
-            "enabled": None,
-            "send_ip_mac_mapping": None
-        },
-
-        "mgmt": {
-            "use_wxtunnel": False
-        },
-
-        "config_auto_revert": True,
-        "status_portal": {
-            "enabled": False,
-            "hostnames": [
-                ""
-            ]
-        },
-        "uplink_port_config": {
-            "keep_wlans_up_if_down": True
-        },
-        "ssh_keys": [],
-        "wids": {},
-        "mxtunnel": {
-            "enabled": False
-        },
-        "occupancy": {
-            "min_duration": None,
-            "clients_enabled": False,
-            "sdkclients_enabled": False,
-            "assets_enabled": False,
-            "unconnected_clients_enabled": False
-        },
-        "public_zone_occupancy": {
-            "enabled": False,
-            "client_density_enabled": False,
-            "rssi_zones_enabled": False
-        },
-        "zone_occupancy_alert": {
-            "enabled": False,
-            "threshold": 5,
-            "email_notifiers": []
-        },
-        "gateway_mgmt": {
-            "app_usage": False,
-            "security_log_source_interface": "",
-            "auto_signature_update": {
-                "enable": True,
-                "time_of_day": "02:00",
-                "day_of_week": ""
-            }
-        },
-        "tunterm_monitoring": [],
-        "tunterm_monitoring_disabled": True,
-        "ssr": {},
-
-        "vars": {
-            "address": d.get('Site Address', ''),
-            "site_name": d.get('Site Name', '')
-        }
-    }
-
-    if 'GovWifi Radius Key' in d:
-        site_setting["vars"]["site_specific_radius_govwifi_secret"] = d.get(
-            'GovWifi Radius Key')
-        site_setting["rogue"]["whitelisted_ssids"] = [
-            "GovWifi"
-        ]
-    if 'Wired NACS Radius Key' in d:
-        site_setting["vars"]["site_specific_radius_wired_nacs_secret"] = d.get(
-            'Wired NACS Radius Key')
-
-    return site, site_setting
-
-
 def plan_of_action(
         data,
         rf_template_id,
         network_template_id,
-        site_group_ids
+        site_group_ids,
+        ap_versions
 ):
 
     # Generate a timestamp for the filename
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     plan_file_name = "../data_src/mist_plan_{time}.json".format(time=timestamp)
-    json_objects = []
 
-    for d in data:
-        site, site_setting = build_payload(
-            d,
-            rf_template_id,
-            network_template_id,
-            site_group_ids
-        )
-        json_objects.append(site)
-        json_objects.append(site_setting)
+    payload_proccesor = BuildPayload(data,
+                     rf_template_id,
+                     network_template_id,
+                     site_group_ids,
+                     ap_versions
+                     )
+
+    processed_payload = payload_proccesor.get_site_payload()
 
     # Load file
     with open(plan_file_name, "w") as plan_file:
-        json.dump(json_objects, plan_file, indent=2)
+        json.dump(processed_payload, plan_file, indent=2)
 
     # Print to terminal
     with open(plan_file_name, "r") as plan_file:
@@ -389,7 +194,6 @@ def juniper_script(
 ):
     # Configure True/False to enable/disable additional logging of the API response objects
     show_more_details = True
-    ap_versions = Admin.get_ap_versions()
 
     validate_user_defined_config_variables(
         org_id,
@@ -407,11 +211,16 @@ def juniper_script(
         data,
         rf_template_id,
         network_template_id,
-        site_group_ids
+        site_group_ids,
+        ap_versions
     )
 
     # Establish Mist session
     admin = Admin(mist_username, mist_login_method)
+
+
+    #TODO get json objects from state here and loop them to upload to mist
+
 
     # Create each site from the CSV file
     for d in data:

--- a/src/juniper.py
+++ b/src/juniper.py
@@ -118,9 +118,6 @@ def juniper_script(
     admin = JuniperClient(mist_username, mist_login_method)
 
 
-    #TODO get json objects from state here and loop them to upload to mist
-
-
     # Create each site from the CSV file
     for site_with_site_setting in payload_processor.get_site_payload():
         # Variables

--- a/src/juniper.py
+++ b/src/juniper.py
@@ -4,11 +4,12 @@ from datetime import datetime
 from build_juniper_payload import BuildPayload
 from juniper_client import JuniperClient
 
+
 def warn_if_using_org_id_production(org_id):
     production_org_ids = [
         '3e824dd6-6b37-4cc7-90bb-97d744e91175',
         '9fd50080-520d-49ec-96a0-09f263fc8a05'
-                          ]
+    ]
     for production_org_id in production_org_ids:
         if org_id == production_org_id:
             production_warning_answer = input(
@@ -117,25 +118,26 @@ def juniper_script(
     # Establish Mist session
     admin = JuniperClient(mist_username, mist_login_method)
 
-
     # Create each site from the CSV file
     for site_with_site_setting in payload_processor.get_site_payload():
         # Variables
         site_id = None
         # print(site_with_site_setting)
 
-
         print('Calling the Mist Create Site API...')
-        result = admin.post('/api/v1/orgs/' + org_id + '/sites', site_with_site_setting["site"])
+        result = admin.post('/api/v1/orgs/' + org_id +
+                            '/sites', site_with_site_setting["site"])
         if result == False:
-            print('Failed to create site {}'.format(site_with_site_setting["site"]['name']))
+            print('Failed to create site {}'.format(
+                site_with_site_setting["site"]['name']))
             print('Skipping remaining operations for this site...')
             print('\n\n==========\n\n')
 
             continue
         else:
             site_id = result['id']
-            print('Created site {} ({})'.format(site_with_site_setting["site"]['name'], site_id))
+            print('Created site {} ({})'.format(
+                site_with_site_setting["site"]['name'], site_id))
 
             if show_more_details:
                 print('\nRetrieving the JSON response object...')
@@ -150,7 +152,8 @@ def juniper_script(
             print('Failed to update site setting {} ({})'.format(
                 site_with_site_setting["site"]['name'], site_id))
         else:
-            print('Updated site setting {} ({})'.format(site_with_site_setting["site"]['name'], site_id))
+            print('Updated site setting {} ({})'.format(
+                site_with_site_setting["site"]['name'], site_id))
 
             if show_more_details:
                 print('\nRetrieving the JSON response object...')

--- a/src/juniper.py
+++ b/src/juniper.py
@@ -123,17 +123,21 @@ def check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(gov_wifi, moj_wi
 
 
 def warn_if_using_org_id_production(org_id):
-    production_org_id = '3e824dd6-6b37-4cc7-90bb-97d744e91175'
-    if org_id == production_org_id:
-        production_warning_answer = input(
-            "Warning you are using production ORG_ID, would you like to proceed? Y/N: ").upper()
-        if production_warning_answer == "Y":
-            print("Continuing with run")
-            return 'Continuing_with_run'
-        elif production_warning_answer == "N":
-            sys.exit()
-        else:
-            raise ValueError('Invalid input')
+    production_org_ids = [
+        '3e824dd6-6b37-4cc7-90bb-97d744e91175',
+        '9fd50080-520d-49ec-96a0-09f263fc8a05'
+                          ]
+    for production_org_id in production_org_ids:
+        if org_id == production_org_id:
+            production_warning_answer = input(
+                "Warning you are using production ORG_ID, would you like to proceed? Y/N: ").upper()
+            if production_warning_answer == "Y":
+                print("Continuing with run")
+                return 'Continuing_with_run'
+            elif production_warning_answer == "N":
+                sys.exit()
+            else:
+                raise ValueError('Invalid input')
 
 
 def build_payload(
@@ -178,7 +182,6 @@ def build_payload(
                 ""
             ],
             "whitelisted_ssids": [
-                "GovWifi"
             ]
         },
 
@@ -288,7 +291,6 @@ def build_payload(
         "ssr": {},
 
         "vars": {
-            "site_specific_radius_wired_nacs_secret": d.get('Wired NACS Radius Key', ''),
             "address": d.get('Site Address', ''),
             "site_name": d.get('Site Name', '')
         }
@@ -297,6 +299,12 @@ def build_payload(
     if 'GovWifi Radius Key' in d:
         site_setting["vars"]["site_specific_radius_govwifi_secret"] = d.get(
             'GovWifi Radius Key')
+        site_setting["rogue"]["whitelisted_ssids"] = [
+            "GovWifi"
+        ]
+    if 'Wired NACS Radius Key' in d:
+        site_setting["vars"]["site_specific_radius_wired_nacs_secret"] = d.get(
+            'Wired NACS Radius Key')
 
     return site, site_setting
 

--- a/src/juniper.py
+++ b/src/juniper.py
@@ -1,101 +1,8 @@
-import requests
 import json
-import getpass
 import sys
 from datetime import datetime
 from build_juniper_payload import BuildPayload
-
-# Mist CRUD operations
-
-
-class Admin:
-
-    def login_via_username_and_password(self, username):
-        # If no username defined ask user
-        if username is None:
-            username = input("Enter Mist Username:")
-        else:
-            print('Username provided: {usr}'.format(usr=username))
-        password = getpass.getpass(prompt='Enter Mist password:')
-        login_url = self.base_url + "/login"
-        login_payload = {'email': username, 'password': password}
-        self.session.post(login_url, data=login_payload)
-        mfa_headers = {
-            # Include CSRF token in headers
-            'X-CSRFToken': self.session.cookies.get('csrftoken.eu'),
-        }
-        self.session.headers.update(mfa_headers)
-        mfa_code = input("Enter MFA:")
-        login_response = self.session.post(
-            "https://api.eu.mist.com/api/v1/login/two_factor",
-            data={"two_factor": mfa_code}
-        )
-        if login_response.status_code == 200:
-            print("Login successful")
-        else:
-            raise ValueError("Login was not successful: {response}".format(
-                response=login_response))
-
-    def login_via_token(self):
-        token = getpass.getpass(prompt='Input the MIST API TOKEN:')
-        self.headers['Authorization'] = 'Token ' + token
-        request_url = self.base_url + "/self/apitokens"
-        responce = self.session.get(request_url, headers=self.headers)
-        if responce.status_code == 200:
-            print("Login successful")
-        else:
-            raise ValueError(
-                "Login was not successful via token: {response}".format(response=responce))
-
-    def __init__(self, username=None, mist_login_method=None):
-        self.session = requests.Session()
-        self.headers = {'Content-Type': 'application/json'}
-        self.base_url = 'https://api.eu.mist.com/api/v1'
-
-        if mist_login_method == 'token':
-            self.login_via_token()
-        elif mist_login_method == 'credentials':
-            self.login_via_username_and_password(username)
-        else:
-            raise ValueError('Invalid mist_login_method: {method}'.format(
-                method=mist_login_method))
-
-    def post(self, url, payload, timeout=60):
-        url = 'https://api.eu.mist.com{}'.format(url)
-        session = self.session
-        headers = self.headers
-
-        print('POST {}'.format(url))
-        response = session.post(url, headers=headers, json=payload)
-
-        if response.status_code != 200:
-            print('Failed to POST')
-            print('\tURL: {}'.format(url))
-            print('\tPayload: {}'.format(payload))
-            print('\tResponse: {} ({})'.format(
-                response.text, response.status_code))
-            return False
-
-        return json.loads(response.text)
-
-    def put(self, url, payload):
-        url = 'https://api.eu.mist.com{}'.format(url)
-        session = self.session
-        headers = self.headers
-
-        print('PUT {}'.format(url))
-        response = session.put(url, headers=headers, json=payload)
-
-        if response.status_code != 200:
-            print('Failed to PUT')
-            print('\tURL: {}'.format(url))
-            print('\tPayload: {}'.format(payload))
-            print('\tResponse: {} ({})'.format(
-                response.text, response.status_code))
-            return False
-
-        return json.loads(response.text)
-
+from juniper_client import JuniperClient
 
 def warn_if_using_org_id_production(org_id):
     production_org_ids = [
@@ -208,7 +115,7 @@ def juniper_script(
     )
 
     # Establish Mist session
-    admin = Admin(mist_username, mist_login_method)
+    admin = JuniperClient(mist_username, mist_login_method)
 
 
     #TODO get json objects from state here and loop them to upload to mist

--- a/src/juniper_client.py
+++ b/src/juniper_client.py
@@ -35,12 +35,12 @@ class JuniperClient:
         token = getpass.getpass(prompt='Input the MIST API TOKEN:')
         self.headers['Authorization'] = 'Token ' + token
         request_url = self.base_url + "/self/apitokens"
-        responce = self.session.get(request_url, headers=self.headers)
-        if responce.status_code == 200:
+        response = self.session.get(request_url, headers=self.headers)
+        if response.status_code == 200:
             print("Login successful")
         else:
             raise ValueError(
-                "Login was not successful via token: {response}".format(response=responce))
+                "Login was not successful via token: {response}".format(response=response))
 
     def __init__(self, username=None, mist_login_method=None):
         self.session = requests.Session()

--- a/src/juniper_client.py
+++ b/src/juniper_client.py
@@ -1,0 +1,91 @@
+import getpass
+import requests
+import json
+
+class JuniperClient:
+
+    def login_via_username_and_password(self, username):
+        # If no username defined ask user
+        if username is None:
+            username = input("Enter Mist Username:")
+        else:
+            print('Username provided: {usr}'.format(usr=username))
+        password = getpass.getpass(prompt='Enter Mist password:')
+        login_url = self.base_url + "/login"
+        login_payload = {'email': username, 'password': password}
+        self.session.post(login_url, data=login_payload)
+        mfa_headers = {
+            # Include CSRF token in headers
+            'X-CSRFToken': self.session.cookies.get('csrftoken.eu'),
+        }
+        self.session.headers.update(mfa_headers)
+        mfa_code = input("Enter MFA:")
+        login_response = self.session.post(
+            "https://api.eu.mist.com/api/v1/login/two_factor",
+            data={"two_factor": mfa_code}
+        )
+        if login_response.status_code == 200:
+            print("Login successful")
+        else:
+            raise ValueError("Login was not successful: {response}".format(
+                response=login_response))
+
+    def login_via_token(self):
+        token = getpass.getpass(prompt='Input the MIST API TOKEN:')
+        self.headers['Authorization'] = 'Token ' + token
+        request_url = self.base_url + "/self/apitokens"
+        responce = self.session.get(request_url, headers=self.headers)
+        if responce.status_code == 200:
+            print("Login successful")
+        else:
+            raise ValueError(
+                "Login was not successful via token: {response}".format(response=responce))
+
+    def __init__(self, username=None, mist_login_method=None):
+        self.session = requests.Session()
+        self.headers = {'Content-Type': 'application/json'}
+        self.base_url = 'https://api.eu.mist.com/api/v1'
+
+        if mist_login_method == 'token':
+            self.login_via_token()
+        elif mist_login_method == 'credentials':
+            self.login_via_username_and_password(username)
+        else:
+            raise ValueError('Invalid mist_login_method: {method}'.format(
+                method=mist_login_method))
+
+    def post(self, url, payload, timeout=60):
+        url = 'https://api.eu.mist.com{}'.format(url)
+        session = self.session
+        headers = self.headers
+
+        print('POST {}'.format(url))
+        response = session.post(url, headers=headers, json=payload)
+
+        if response.status_code != 200:
+            print('Failed to POST')
+            print('\tURL: {}'.format(url))
+            print('\tPayload: {}'.format(payload))
+            print('\tResponse: {} ({})'.format(
+                response.text, response.status_code))
+            return False
+
+        return json.loads(response.text)
+
+    def put(self, url, payload):
+        url = 'https://api.eu.mist.com{}'.format(url)
+        session = self.session
+        headers = self.headers
+
+        print('PUT {}'.format(url))
+        response = session.put(url, headers=headers, json=payload)
+
+        if response.status_code != 200:
+            print('Failed to PUT')
+            print('\tURL: {}'.format(url))
+            print('\tPayload: {}'.format(payload))
+            print('\tResponse: {} ({})'.format(
+                response.text, response.status_code))
+            return False
+
+        return json.loads(response.text)

--- a/src/juniper_client.py
+++ b/src/juniper_client.py
@@ -2,6 +2,7 @@ import getpass
 import requests
 import json
 
+
 class JuniperClient:
 
     def login_via_username_and_password(self, username):

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,3 @@
-import sys
-
 from juniper import juniper_script
 import os
 import csv

--- a/src/main.py
+++ b/src/main.py
@@ -62,5 +62,6 @@ if __name__ == '__main__':
         org_id=os.environ.get('ORG_ID'),
         rf_template_id=os.environ.get('RF_TEMPLATE_ID'),
         data=json_data_with_geocoding,
-        network_template_id=os.environ.get('NETWORK_TEMPLATE_ID')
+        network_template_id=os.environ.get('NETWORK_TEMPLATE_ID'),
+        ap_versions=os.environ.get('AP_VERSIONS')
     )

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,8 +3,3 @@ geopy==2.4.1
 timezonefinder==6.2.0
 pytest==8.1.1
 parameterized==0.9.0
-
-
-
-
-

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,3 +2,9 @@ requests==2.31.0
 geopy==2.4.1
 timezonefinder==6.2.0
 pytest==8.1.1
+parameterized==0.9.0
+
+
+
+
+

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.31.0
 geopy==2.4.1
 timezonefinder==6.2.0
+pytest==8.1.1

--- a/test/test_build_juniper_payload.py
+++ b/test/test_build_juniper_payload.py
@@ -1,0 +1,50 @@
+from src.build_juniper_payload import BuildPayload
+import unittest
+
+class TestBuildPayLoad(unittest.TestCase):
+    def setUp(self):
+        self.inputt = [
+            {
+              'Site Name': 'MOJ-0137-Probation-Gloucestershire-TwyverHouse',
+              'Site Address': 'Twyver House, Bruton Way, Gloucester, GL1 1PB',
+              'Enable GovWifi': 'FALSE', 'Enable MoJWifi': 'FALSE',
+              'Wired NACS Radius Key': 'B49DA885C90D8977F984',
+              'gps': (51.86467215, -2.2396225106929535),
+              'country_code': 'GB', 'time_zone': 'Europe/London'
+            },
+            {
+              'Site Name': 'Test location 2',
+              'Site Address': '102 Petty France, London SW1H 9AJ',
+              'Enable GovWifi': 'FALSE', 'Enable MoJWifi': 'FALSE',
+              'Wired NACS Radius Key': '00000DD0000BC0EEE000',
+              'gps': (51.499929300000005, -0.13477761285315926),
+              'country_code': 'GB', 'time_zone': 'Europe/London'
+            },
+            {
+              'Site Name': 'Test location 3',
+              'Site Address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB',
+              'Enable GovWifi': 'FALSE', 'Enable MoJWifi': 'FALSE',
+              'Wired NACS Radius Key': '00000DD0000BC0EEE000', 'gps': (50.727350349999995, -3.4744726127760086),
+              'country_code': 'GB', 'time_zone': 'Europe/London'
+            }
+        ]
+        self.payload_processor = BuildPayload(
+                data = self.inputt,
+                rf_template_id = "rf_template_id",
+                network_template_id = "network_template_id",
+                site_group_ids = {"moj_wifi": "foo","gov_wifi": "bar"},
+                ap_versions = {"AP45": "0.12.27139", "AP32": "0.12.27139"}
+            )
+
+    def test_something(self):
+        # result = self.payload_processor.get_site_payload()
+        print(self.input)
+
+        # self.assertEqual(result[0], {'address': '123 Main St',
+        #                              'country_code': 'US',
+        #                              'latlng': {'lat': 1.23,'lng': 4.56},
+        #                              'name': 'TestSite',
+        #                              'networktemplate_id': ('network_template_id',),
+        #                              'rftemplate_id': ('rf_template_id',),
+        #                              'sitegroup_ids': [],
+        #                              'timezone': 'UTC'})

--- a/test/test_build_juniper_payload.py
+++ b/test/test_build_juniper_payload.py
@@ -88,11 +88,11 @@ class TestBuildPayLoad(unittest.TestCase):
                      'site_name': 'MOJ-0137-Probation-Gloucestershire-TwyverHouse',
                      'site_specific_radius_govwifi_secret': 'govwifi_secret',
                      'site_specific_radius_wired_nacs_secret': 'wired_nacs_secret'}}}, {
-                                'site': {'name': 'Test location 2', 'address': '102 Petty France, London SW1H 9AJ',
-                                         'latlng': {'lat': 51.499929300000005, 'lng': -0.13477761285315926},
-                                         'country_code': 'GB', 'rftemplate_id': 'rf_template_123',
-                                         'networktemplate_id': 'network_template_123', 'timezone': 'Europe/London',
-                                         'sitegroup_ids': []}, 'site_setting': {
+            'site': {'name': 'Test location 2', 'address': '102 Petty France, London SW1H 9AJ',
+                     'latlng': {'lat': 51.499929300000005, 'lng': -0.13477761285315926},
+                     'country_code': 'GB', 'rftemplate_id': 'rf_template_123',
+                     'networktemplate_id': 'network_template_123', 'timezone': 'Europe/London',
+                     'sitegroup_ids': []}, 'site_setting': {
                 'auto_upgrade': {'enabled': True, 'version': 'custom', 'time_of_day': '02:00',
                                  'custom_versions': {'ap_version_1': '1.0', 'ap_version_2': '2.0'}, 'day_of_week': ''},
                 'rogue': {'min_rssi': -80, 'min_duration': 20, 'enabled': True, 'honeypot_enabled': True,
@@ -117,15 +117,15 @@ class TestBuildPayLoad(unittest.TestCase):
                                           'rssi_zones_enabled': False},
                 'zone_occupancy_alert': {'enabled': False, 'threshold': 5, 'email_notifiers': []},
                 'gateway_mgmt': {'app_usage': False, 'security_log_source_interface': '',
-                                 'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
+                                                     'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
                 'tunterm_monitoring': [], 'tunterm_monitoring_disabled': True, 'ssr': {},
                 'vars': {'address': '102 Petty France, London SW1H 9AJ', 'site_name': 'Test location 2'}}}, {
-                                'site': {'name': 'Test location 3',
-                                         'address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB',
-                                         'latlng': {'lat': 50.727350349999995, 'lng': -3.4744726127760086},
-                                         'country_code': 'GB', 'rftemplate_id': 'rf_template_123',
-                                         'networktemplate_id': 'network_template_123', 'timezone': 'Europe/London',
-                                         'sitegroup_ids': []}, 'site_setting': {
+            'site': {'name': 'Test location 3',
+                     'address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB',
+                     'latlng': {'lat': 50.727350349999995, 'lng': -3.4744726127760086},
+                     'country_code': 'GB', 'rftemplate_id': 'rf_template_123',
+                     'networktemplate_id': 'network_template_123', 'timezone': 'Europe/London',
+                     'sitegroup_ids': []}, 'site_setting': {
                 'auto_upgrade': {'enabled': True, 'version': 'custom', 'time_of_day': '02:00',
                                  'custom_versions': {'ap_version_1': '1.0', 'ap_version_2': '2.0'}, 'day_of_week': ''},
                 'rogue': {'min_rssi': -80, 'min_duration': 20, 'enabled': True, 'honeypot_enabled': True,
@@ -150,10 +150,10 @@ class TestBuildPayLoad(unittest.TestCase):
                                           'rssi_zones_enabled': False},
                 'zone_occupancy_alert': {'enabled': False, 'threshold': 5, 'email_notifiers': []},
                 'gateway_mgmt': {'app_usage': False, 'security_log_source_interface': '',
-                                 'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
+                                                     'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
                 'tunterm_monitoring': [], 'tunterm_monitoring_disabled': True, 'ssr': {},
                 'vars': {'address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB', 'site_name': 'Test location 3',
-                         'site_specific_radius_wired_nacs_secret': 'wired_nacs_secret'}}}]
+                                             'site_specific_radius_wired_nacs_secret': 'wired_nacs_secret'}}}]
 
         self.assertEqual(payload_processor, expected_results)
 
@@ -169,6 +169,7 @@ class TestBuildPayLoad(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Missing the following keys ['Site Name', 'Site Address', 'gps', 'country_code', 'time_zone', 'Enable GovWifi', 'Enable MoJWifi']")
+
 
 class TestCheckIfNeedToAppend(unittest.TestCase):
 
@@ -212,7 +213,8 @@ class TestCheckIfNeedToAppend(unittest.TestCase):
         ]
         self.rf_template_id = "rf_template_123"
         self.network_template_id = "network_template_123"
-        self.site_group_ids = {"moj_wifi": "moj_wifi_id", "gov_wifi": "gov_wifi_id"}
+        self.site_group_ids = {
+            "moj_wifi": "moj_wifi_id", "gov_wifi": "gov_wifi_id"}
         self.ap_versions = {"ap_version_1": "1.0", "ap_version_2": "2.0"}
         self.payload_processor = BuildPayload(
             data=self.sample_data,
@@ -226,7 +228,7 @@ class TestCheckIfNeedToAppend(unittest.TestCase):
         gov_wifi = 'TRUE'
         moj_wifi = 'FALSE'
         result = self.payload_processor._check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(
-            gov_wifi, moj_wifi,self.site_group_ids)
+            gov_wifi, moj_wifi, self.site_group_ids)
         self.assertEqual(result, [self.site_group_ids['gov_wifi']])
 
     def test_append_moj_wifi(self):

--- a/test/test_build_juniper_payload.py
+++ b/test/test_build_juniper_payload.py
@@ -1,50 +1,170 @@
 from src.build_juniper_payload import BuildPayload
 import unittest
 
+
 class TestBuildPayLoad(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
-        self.inputt = [
+        self.sample_data = [
             {
-              'Site Name': 'MOJ-0137-Probation-Gloucestershire-TwyverHouse',
-              'Site Address': 'Twyver House, Bruton Way, Gloucester, GL1 1PB',
-              'Enable GovWifi': 'FALSE', 'Enable MoJWifi': 'FALSE',
-              'Wired NACS Radius Key': 'B49DA885C90D8977F984',
-              'gps': (51.86467215, -2.2396225106929535),
-              'country_code': 'GB', 'time_zone': 'Europe/London'
+                'Site Name': 'MOJ-0137-Probation-Gloucestershire-TwyverHouse',
+                'Site Address': 'Twyver House, Bruton Way, Gloucester, GL1 1PB',
+                'gps': [51.86467215, -2.2396225106929535],
+                'country_code': 'GB',
+                'time_zone': 'Europe/London',
+                'Enable GovWifi': 'True',
+                'Enable MoJWifi': 'True',
+                'GovWifi Radius Key': 'govwifi_secret',
+                'Wired NACS Radius Key': 'wired_nacs_secret'
             },
             {
-              'Site Name': 'Test location 2',
-              'Site Address': '102 Petty France, London SW1H 9AJ',
-              'Enable GovWifi': 'FALSE', 'Enable MoJWifi': 'FALSE',
-              'Wired NACS Radius Key': '00000DD0000BC0EEE000',
-              'gps': (51.499929300000005, -0.13477761285315926),
-              'country_code': 'GB', 'time_zone': 'Europe/London'
+                'Site Name': 'Test location 2',
+                'Site Address': '102 Petty France, London SW1H 9AJ',
+                'gps': [51.499929300000005, -0.13477761285315926],
+                'country_code': 'GB',
+                'time_zone': 'Europe/London',
+                'Enable GovWifi': 'False',
+                'Enable MoJWifi': 'False'
             },
             {
-              'Site Name': 'Test location 3',
-              'Site Address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB',
-              'Enable GovWifi': 'FALSE', 'Enable MoJWifi': 'FALSE',
-              'Wired NACS Radius Key': '00000DD0000BC0EEE000', 'gps': (50.727350349999995, -3.4744726127760086),
-              'country_code': 'GB', 'time_zone': 'Europe/London'
+                'Site Name': 'Test location 3',
+                'Site Address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB',
+                'gps': [50.727350349999995, -3.4744726127760086],
+                'country_code': 'GB',
+                'time_zone': 'Europe/London',
+                'Enable GovWifi': 'False',
+                'Enable MoJWifi': 'True',
+                'Wired NACS Radius Key': 'wired_nacs_secret'
             }
         ]
-        self.payload_processor = BuildPayload(
-                data = self.inputt,
-                rf_template_id = "rf_template_id",
-                network_template_id = "network_template_id",
-                site_group_ids = {"moj_wifi": "foo","gov_wifi": "bar"},
-                ap_versions = {"AP45": "0.12.27139", "AP32": "0.12.27139"}
+
+        self.rf_template_id = "rf_template_123"
+        self.network_template_id = "network_template_123"
+        self.site_group_ids = '{"moj_wifi": "moj_wifi_id", "gov_wifi": "gov_wifi_id"}'
+        self.ap_versions = {"ap_version_1": "1.0", "ap_version_2": "2.0"}
+
+    def test_given_valid_data_when_get_site_payload_called_then_return_built_site_payload(self):
+        payload_processor = BuildPayload(
+            data=self.sample_data,
+            rf_template_id=self.rf_template_id,
+            network_template_id=self.network_template_id,
+            site_group_ids=self.site_group_ids,
+            ap_versions=self.ap_versions
+        ).get_site_payload()
+
+        expected_results = [{'site': {'name': 'MOJ-0137-Probation-Gloucestershire-TwyverHouse',
+                                      'address': 'Twyver House, Bruton Way, Gloucester, GL1 1PB',
+                                      'latlng': {'lat': 51.86467215, 'lng': -2.2396225106929535}, 'country_code': 'GB',
+                                      'rftemplate_id': 'rf_template_123', 'networktemplate_id': 'network_template_123',
+                                      'timezone': 'Europe/London', 'sitegroup_ids': []}, 'site_setting': {
+            'auto_upgrade': {'enabled': True, 'version': 'custom', 'time_of_day': '02:00',
+                             'custom_versions': {'ap_version_1': '1.0', 'ap_version_2': '2.0'}, 'day_of_week': ''},
+            'rogue': {'min_rssi': -80, 'min_duration': 20, 'enabled': True, 'honeypot_enabled': True,
+                      'whitelisted_bssids': [''], 'whitelisted_ssids': ['GovWifi']}, 'persist_config_on_device': True,
+            'engagement': {'dwell_tags': {'passerby': '1-300', 'bounce': '3600-14400', 'engaged': '25200-36000',
+                                          'stationed': '50400-86400'},
+                           'dwell_tag_names': {'passerby': 'Below 5 Min (Passerby)', 'bounce': '1-4 Hours',
+                                               'engaged': '7-10 Hours', 'stationed': '14-24 Hours'},
+                           'hours': {'sun': None, 'mon': None, 'tue': None, 'wed': None, 'thu': None, 'fri': None,
+                                     'sat': None}}, 'analytic': {'enabled': True},
+            'rtsa': {'enabled': False, 'track_asset': False, 'app_waking': False},
+            'led': {'enabled': True, 'brightness': 255},
+            'wifi': {'enabled': True, 'locate_unconnected': True, 'mesh_enabled': False, 'mesh_allow_dfs': False},
+            'switch_mgmt': {'use_mxedge_proxy': False, 'mxedge_proxy_port': '2222'}, 'wootcloud': None,
+            'skyatp': {'enabled': None, 'send_ip_mac_mapping': None}, 'mgmt': {'use_wxtunnel': False},
+            'config_auto_revert': True, 'status_portal': {'enabled': False, 'hostnames': ['']},
+            'uplink_port_config': {'keep_wlans_up_if_down': True}, 'ssh_keys': [], 'wids': {},
+            'mxtunnel': {'enabled': False},
+            'occupancy': {'min_duration': None, 'clients_enabled': False, 'sdkclients_enabled': False,
+                          'assets_enabled': False, 'unconnected_clients_enabled': False},
+            'public_zone_occupancy': {'enabled': False, 'client_density_enabled': False, 'rssi_zones_enabled': False},
+            'zone_occupancy_alert': {'enabled': False, 'threshold': 5, 'email_notifiers': []},
+            'gateway_mgmt': {'app_usage': False, 'security_log_source_interface': '',
+                             'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
+            'tunterm_monitoring': [], 'tunterm_monitoring_disabled': True, 'ssr': {},
+            'vars': {'address': 'Twyver House, Bruton Way, Gloucester, GL1 1PB',
+                     'site_name': 'MOJ-0137-Probation-Gloucestershire-TwyverHouse',
+                     'site_specific_radius_govwifi_secret': 'govwifi_secret',
+                     'site_specific_radius_wired_nacs_secret': 'wired_nacs_secret'}}}, {
+                                'site': {'name': 'Test location 2', 'address': '102 Petty France, London SW1H 9AJ',
+                                         'latlng': {'lat': 51.499929300000005, 'lng': -0.13477761285315926},
+                                         'country_code': 'GB', 'rftemplate_id': 'rf_template_123',
+                                         'networktemplate_id': 'network_template_123', 'timezone': 'Europe/London',
+                                         'sitegroup_ids': []}, 'site_setting': {
+                'auto_upgrade': {'enabled': True, 'version': 'custom', 'time_of_day': '02:00',
+                                 'custom_versions': {'ap_version_1': '1.0', 'ap_version_2': '2.0'}, 'day_of_week': ''},
+                'rogue': {'min_rssi': -80, 'min_duration': 20, 'enabled': True, 'honeypot_enabled': True,
+                          'whitelisted_bssids': [''], 'whitelisted_ssids': []}, 'persist_config_on_device': True,
+                'engagement': {'dwell_tags': {'passerby': '1-300', 'bounce': '3600-14400', 'engaged': '25200-36000',
+                                              'stationed': '50400-86400'},
+                               'dwell_tag_names': {'passerby': 'Below 5 Min (Passerby)', 'bounce': '1-4 Hours',
+                                                   'engaged': '7-10 Hours', 'stationed': '14-24 Hours'},
+                               'hours': {'sun': None, 'mon': None, 'tue': None, 'wed': None, 'thu': None, 'fri': None,
+                                         'sat': None}}, 'analytic': {'enabled': True},
+                'rtsa': {'enabled': False, 'track_asset': False, 'app_waking': False},
+                'led': {'enabled': True, 'brightness': 255},
+                'wifi': {'enabled': True, 'locate_unconnected': True, 'mesh_enabled': False, 'mesh_allow_dfs': False},
+                'switch_mgmt': {'use_mxedge_proxy': False, 'mxedge_proxy_port': '2222'}, 'wootcloud': None,
+                'skyatp': {'enabled': None, 'send_ip_mac_mapping': None}, 'mgmt': {'use_wxtunnel': False},
+                'config_auto_revert': True, 'status_portal': {'enabled': False, 'hostnames': ['']},
+                'uplink_port_config': {'keep_wlans_up_if_down': True}, 'ssh_keys': [], 'wids': {},
+                'mxtunnel': {'enabled': False},
+                'occupancy': {'min_duration': None, 'clients_enabled': False, 'sdkclients_enabled': False,
+                              'assets_enabled': False, 'unconnected_clients_enabled': False},
+                'public_zone_occupancy': {'enabled': False, 'client_density_enabled': False,
+                                          'rssi_zones_enabled': False},
+                'zone_occupancy_alert': {'enabled': False, 'threshold': 5, 'email_notifiers': []},
+                'gateway_mgmt': {'app_usage': False, 'security_log_source_interface': '',
+                                 'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
+                'tunterm_monitoring': [], 'tunterm_monitoring_disabled': True, 'ssr': {},
+                'vars': {'address': '102 Petty France, London SW1H 9AJ', 'site_name': 'Test location 2'}}}, {
+                                'site': {'name': 'Test location 3',
+                                         'address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB',
+                                         'latlng': {'lat': 50.727350349999995, 'lng': -3.4744726127760086},
+                                         'country_code': 'GB', 'rftemplate_id': 'rf_template_123',
+                                         'networktemplate_id': 'network_template_123', 'timezone': 'Europe/London',
+                                         'sitegroup_ids': []}, 'site_setting': {
+                'auto_upgrade': {'enabled': True, 'version': 'custom', 'time_of_day': '02:00',
+                                 'custom_versions': {'ap_version_1': '1.0', 'ap_version_2': '2.0'}, 'day_of_week': ''},
+                'rogue': {'min_rssi': -80, 'min_duration': 20, 'enabled': True, 'honeypot_enabled': True,
+                          'whitelisted_bssids': [''], 'whitelisted_ssids': []}, 'persist_config_on_device': True,
+                'engagement': {'dwell_tags': {'passerby': '1-300', 'bounce': '3600-14400', 'engaged': '25200-36000',
+                                              'stationed': '50400-86400'},
+                               'dwell_tag_names': {'passerby': 'Below 5 Min (Passerby)', 'bounce': '1-4 Hours',
+                                                   'engaged': '7-10 Hours', 'stationed': '14-24 Hours'},
+                               'hours': {'sun': None, 'mon': None, 'tue': None, 'wed': None, 'thu': None, 'fri': None,
+                                         'sat': None}}, 'analytic': {'enabled': True},
+                'rtsa': {'enabled': False, 'track_asset': False, 'app_waking': False},
+                'led': {'enabled': True, 'brightness': 255},
+                'wifi': {'enabled': True, 'locate_unconnected': True, 'mesh_enabled': False, 'mesh_allow_dfs': False},
+                'switch_mgmt': {'use_mxedge_proxy': False, 'mxedge_proxy_port': '2222'}, 'wootcloud': None,
+                'skyatp': {'enabled': None, 'send_ip_mac_mapping': None}, 'mgmt': {'use_wxtunnel': False},
+                'config_auto_revert': True, 'status_portal': {'enabled': False, 'hostnames': ['']},
+                'uplink_port_config': {'keep_wlans_up_if_down': True}, 'ssh_keys': [], 'wids': {},
+                'mxtunnel': {'enabled': False},
+                'occupancy': {'min_duration': None, 'clients_enabled': False, 'sdkclients_enabled': False,
+                              'assets_enabled': False, 'unconnected_clients_enabled': False},
+                'public_zone_occupancy': {'enabled': False, 'client_density_enabled': False,
+                                          'rssi_zones_enabled': False},
+                'zone_occupancy_alert': {'enabled': False, 'threshold': 5, 'email_notifiers': []},
+                'gateway_mgmt': {'app_usage': False, 'security_log_source_interface': '',
+                                 'auto_signature_update': {'enable': True, 'time_of_day': '02:00', 'day_of_week': ''}},
+                'tunterm_monitoring': [], 'tunterm_monitoring_disabled': True, 'ssr': {},
+                'vars': {'address': 'Met Office, FitzRoy Road, Exeter, Devon, EX1 3PB', 'site_name': 'Test location 3',
+                         'site_specific_radius_wired_nacs_secret': 'wired_nacs_secret'}}}]
+
+        self.assertEqual(payload_processor, expected_results)
+
+    def test_given_invalid_data_when_get_site_payload_called_then_raise_error(self):
+        with self.assertRaises(ValueError) as cm:
+            BuildPayload(
+                data=["I hate bad formatting!"],
+                rf_template_id=self.rf_template_id,
+                network_template_id=self.network_template_id,
+                site_group_ids=self.site_group_ids,
+                ap_versions=self.ap_versions
             )
 
-    def test_something(self):
-        # result = self.payload_processor.get_site_payload()
-        print(self.input)
-
-        # self.assertEqual(result[0], {'address': '123 Main St',
-        #                              'country_code': 'US',
-        #                              'latlng': {'lat': 1.23,'lng': 4.56},
-        #                              'name': 'TestSite',
-        #                              'networktemplate_id': ('network_template_id',),
-        #                              'rftemplate_id': ('rf_template_id',),
-        #                              'sitegroup_ids': [],
-        #                              'timezone': 'UTC'})
+        self.assertEqual(str(cm.exception),
+                         "Missing the following keys ['Site Name', 'Site Address', 'gps', 'country_code', 'time_zone', 'Enable GovWifi', 'Enable MoJWifi']")

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -11,13 +11,14 @@ from parameterized import parameterized
 class TestJuniperScript(unittest.TestCase):
 
     @patch('src.juniper.plan_of_action')
-    @patch('getpass.getpass', return_value='token')
-    @patch('src.juniper.requests.Session.get', return_value=MagicMock(status_code=200))
-    @patch('src.juniper.JuniperClient.post')
-    @patch('src.juniper.JuniperClient.put')
-    def test_juniper_script_with_govwifi(self, mock_put, mock_post, mock_successful_login, api_token, mock_plan_of_action):
+    @patch('src.juniper.JuniperClient')
+    def test_given_successful_login_when_juniper_script_runs_post_a_site(self, mock_juniper_client, mock_plan_of_action):
+
         # Mock Mist API responses
+        mock_post = mock_juniper_client.return_value.post
         mock_post.return_value = {'id': '123', 'name': 'TestSite'}
+
+        mock_put = mock_juniper_client.return_value.put
         mock_put.return_value = {'status': 'success'}
 
         # Sample input data
@@ -35,49 +36,10 @@ class TestJuniperScript(unittest.TestCase):
             org_id='your_org_id',
             site_group_ids='{"moj_wifi": "foo","gov_wifi": "bar"}',
             rf_template_id='8542a5fa-51e4-41be-83b9-acb416362cc0',
-            network_template_id='46b87163-abd2-4b08-a67f-1ccecfcfd061'
+            network_template_id='46b87163-abd2-4b08-a67f-1ccecfcfd061',
+            ap_versions={"AP45": "0.12.27139", "AP32": "0.12.27139"}
         )
 
-        # Assertions
-        mock_plan_of_action.assert_called_once_with([{'Site Name': 'TestSite', 'Site Address': '123 Main St', 'gps': [1.23, 4.56], 'country_code': 'US', 'time_zone': 'UTC', 'Enable GovWifi': 'true', 'Enable MoJWifi': 'false',
-                                                    'Wired NACS Radius Key': 'key1', 'GovWifi Radius Key': 'key2'}], '8542a5fa-51e4-41be-83b9-acb416362cc0', '46b87163-abd2-4b08-a67f-1ccecfcfd061', '{"moj_wifi": "foo","gov_wifi": "bar"}')
-        mock_post.assert_called_once_with('/api/v1/orgs/your_org_id/sites',
-                                          {'name': 'TestSite', 'address': '123 Main St',
-                                           'latlng': {'lat': 1.23, 'lng': 4.56}, 'country_code': 'US',
-                                           'rftemplate_id': '8542a5fa-51e4-41be-83b9-acb416362cc0',
-                                           'networktemplate_id': '46b87163-abd2-4b08-a67f-1ccecfcfd061',
-                                           'timezone': 'UTC', 'sitegroup_ids': []})
-
-    @patch('src.juniper.plan_of_action')
-    @patch('getpass.getpass', return_value='token')
-    @patch('src.juniper.requests.Session.get', return_value=MagicMock(status_code=200))
-    @patch('src.juniper.Admin.post')
-    @patch('src.juniper.Admin.put')
-    def test_juniper_script_without_gov_wifi(self, mock_put, mock_post, mock_successful_login, api_token, mock_plan_of_action):
-        # Mock Mist API responses
-        mock_post.return_value = {'id': '123', 'name': 'TestSite'}
-        mock_put.return_value = {'status': 'success'}
-
-        # Sample input data
-        data = [
-            {'Site Name': 'TestSite', 'Site Address': '123 Main St',
-             'gps': [1.23, 4.56], 'country_code': 'US', 'time_zone': 'UTC',
-             'Enable GovWifi': 'true', 'Enable MoJWifi': 'false'}
-        ]
-
-        # Call the function
-        juniper_script(
-            data,
-            mist_login_method='token',
-            org_id='your_org_id',
-            site_group_ids='{"moj_wifi": "foo","gov_wifi": "bar"}',
-            rf_template_id='8542a5fa-51e4-41be-83b9-acb416362cc0',
-            network_template_id='46b87163-abd2-4b08-a67f-1ccecfcfd061'
-        )
-
-        # Assertions
-        mock_plan_of_action.assert_called_once_with([{'Site Name': 'TestSite', 'Site Address': '123 Main St', 'gps': [1.23, 4.56], 'country_code': 'US', 'time_zone': 'UTC',
-                                                    'Enable GovWifi': 'true', 'Enable MoJWifi': 'false'}], '8542a5fa-51e4-41be-83b9-acb416362cc0', '46b87163-abd2-4b08-a67f-1ccecfcfd061', '{"moj_wifi": "foo","gov_wifi": "bar"}')
         mock_post.assert_called_once_with('/api/v1/orgs/your_org_id/sites',
                                           {'name': 'TestSite', 'address': '123 Main St',
                                            'latlng': {'lat': 1.23, 'lng': 4.56}, 'country_code': 'US',

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from src.juniper import juniper_script, Admin, check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups, \
-    warn_if_using_org_id_production, plan_of_action
+    warn_if_using_org_id_production, plan_of_action, build_payload
 from io import StringIO
 from datetime import datetime
 import os
@@ -338,6 +338,35 @@ class TestCheckIfNeedToAppend(unittest.TestCase):
         result = check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(
             gov_wifi, moj_wifi, self.site_group_ids)
         self.assertEqual(result, [])
+
+
+class TestBuildPayLoadFunction(unittest.TestCase):
+    def setUp(self):
+        self.data = {'Site Name': 'TestSite', 'Site Address': '123 Main St',
+                     'gps': [1.23, 4.56], 'country_code': 'US', 'time_zone': 'UTC',
+                     'Enable GovWifi': 'true', 'Enable MoJWifi': 'false',
+                     'Wired NACS Radius Key': 'key1', 'GovWifi Radius Key': 'key2'}
+        self.rf_template_id = "rf_template_id",
+        self.network_template_id = "network_template_id",
+        self.site_group_ids = '{"moj_wifi": "foo","gov_wifi": "bar"}'
+
+    def test_something(self):
+        result = build_payload(self.data,
+                      self.rf_template_id,
+                      self.network_template_id,
+                      self.site_group_ids)
+
+
+        self.assertEqual(result[0], {'address': '123 Main St',
+                                       'country_code': 'US',
+                                       'latlng': {'lat': 1.23,'lng': 4.56},
+                                       'name': 'TestSite',
+                                       'networktemplate_id': ('network_template_id',),
+                                       'rftemplate_id': ('rf_template_id',),
+                                       'sitegroup_ids': [],
+                                       'timezone': 'UTC'})
+        print("h")
+
 
 
 class TestPlanOfActionFunction(unittest.TestCase):

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -5,7 +5,7 @@ from src.juniper import juniper_script, Admin, check_if_we_need_to_append_gov_wi
 from io import StringIO
 from datetime import datetime
 import os
-
+import pytest
 
 class TestJuniperScript(unittest.TestCase):
 
@@ -105,10 +105,17 @@ class TestJuniperScript(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), 'Must define rf_template_id')
 
-    @patch('builtins.input', return_value='y')
+
+    @pytest.mark.parametrize("fixt", ["a", "b"], indirect=True)
+    def test_indirect(self, fixt):
+        assert len(fixt) == 3
+
+    @pytest.mark.parametrize("production_org_id", ['3e824dd6-6b37-4cc7-90bb-97d744e91175','9fd50080-520d-49ec-96a0-09f263fc8a05'])
+    #@patch('builtins.input', return_value='y')
     def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_y_then_continue_to_run(self,
-                                                                                                         user_input):
-        production_org_id = '3e824dd6-6b37-4cc7-90bb-97d744e91175'
+                                                                                                         production_org_id
+                                                                                                         ):
+        print(production_org_id)
         result = warn_if_using_org_id_production(production_org_id)
         self.assertEqual(result, 'Continuing_with_run')
 

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -6,6 +6,7 @@ from io import StringIO
 from datetime import datetime
 import os
 import pytest
+from parameterized import parameterized
 
 class TestJuniperScript(unittest.TestCase):
 
@@ -105,19 +106,17 @@ class TestJuniperScript(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), 'Must define rf_template_id')
 
-
-    @pytest.mark.parametrize("fixt", ["a", "b"], indirect=True)
-    def test_indirect(self, fixt):
-        assert len(fixt) == 3
-
-    @pytest.mark.parametrize("production_org_id", ['3e824dd6-6b37-4cc7-90bb-97d744e91175','9fd50080-520d-49ec-96a0-09f263fc8a05'])
-    #@patch('builtins.input', return_value='y')
-    def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_y_then_continue_to_run(self,
-                                                                                                         production_org_id
+    @parameterized.expand(
+        "production_org_id", ["3e824dd6-6b37-4cc7-90bb-97d744e91175",
+         "9fd50080-520d-49ec-96a0-09f263fc8a05"
+    ])
+    @patch('builtins.input', return_value='y')
+    def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_y_then_continue_to_run(self, user_input,
+                                                                                                         production_org_id,
                                                                                                          ):
         print(production_org_id)
         result = warn_if_using_org_id_production(production_org_id)
-        self.assertEqual(result, 'Continuing_with_run')
+        self.assertEqual('Continuing_with_run', result)
 
     @patch('builtins.input', return_value='n')
     def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_n_then_sys_exit(self, user_input):

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from src.juniper import juniper_script, Admin, check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups, \
-    warn_if_using_org_id_production, plan_of_action, build_payload
+from src.juniper import juniper_script, check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups, \
+    warn_if_using_org_id_production, plan_of_action
 from io import StringIO
 from datetime import datetime
 import os
@@ -182,122 +182,24 @@ class TestJuniperScript(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), 'Please provide Mist org_id')
 
-    # Mocking the input function to provide a static MFA code
-    @patch('getpass.getpass', return_value='password')
-    @patch('builtins.input', return_value='123456')
-    @patch('src.juniper.requests.Session.post', return_value=MagicMock(status_code=200))
-    def test_login_successfully_via_username_and_password(self, mock_post, input_mfa, input_password):
-        admin = Admin(username='test@example.com',
-                      mist_login_method='credentials')
-        self.assertIsNotNone(admin)
 
-        mock_post.assert_called_with(
-            'https://api.eu.mist.com/api/v1/login/two_factor', data={'two_factor': '123456'})
-        self.assertEqual(mock_post.call_count, 2)
 
-    @patch('getpass.getpass', return_value='password')
-    @patch('builtins.input', return_value='123456')
-    @patch('src.juniper.requests.Session.post', return_value=MagicMock(status_code=400))
-    def test_given_valid_username_and_password_when_post_to_api_and_non_200_status_code_received_then_raise_error_to_user(
-            self, mock_post, mfa_input, password_input):
-        with self.assertRaises(ValueError) as context:
-            admin = Admin(username='test@example.com',
-                          mist_login_method='credentials')
 
-        # Check the expected part of the exception message
-        expected_error_message = "Login was not successful:"
-        self.assertTrue(expected_error_message in str(context.exception))
-
-        # Ensure the post method is called with the correct parameters
-        mock_post.assert_called_with(
-            'https://api.eu.mist.com/api/v1/login/two_factor',
-            data={'two_factor': '123456'}
-        )
-
-        # Ensure the post method is called twice
-        self.assertEqual(mock_post.call_count, 2)
-
-    @patch('getpass.getpass', return_value='test_token')
-    @patch('src.juniper.requests.Session')
-    def test_given_valid_api_token_when_post_to_api_and_non_200_status_code_received_then_raise_error_to_user(self,
-                                                                                                              mock_session,
-                                                                                                              api_token):
-        mock_get = mock_session.return_value.get
-        mock_get.return_value = MagicMock(status_code=400)
-
-        with self.assertRaises(ValueError) as context:
-            admin = Admin(mist_login_method='token')
-
-        # Check the expected part of the exception message
-        expected_error_message = "Login was not successful via token:"
-        self.assertTrue(expected_error_message in str(context.exception))
-
-        # Ensure the get method is called with the correct parameters
-        expected_url = 'https://api.eu.mist.com/api/v1/self/apitokens'
-        mock_get.assert_called_with(expected_url,
-                                    headers={'Content-Type': 'application/json',
-                                             'Authorization': 'Token test_token'}
-                                    )
-
-        self.assertEqual(mock_get.call_count, 1)
-
-    @patch('getpass.getpass', return_value='token')
-    @patch('src.juniper.requests.Session.get', return_value=MagicMock(status_code=200))
-    @patch('src.juniper.requests.Session.post')
-    def test_post(self, mock_post, mock_successful_login, input_api_token):
-        # Set up the mock to return a response with a valid JSON payload
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = '{"key": "value"}'
-        mock_post.return_value = mock_response
-
-        admin = Admin(mist_login_method='token')
-        self.assertIsNotNone(admin)
-
-        result = admin.post('/some_endpoint', {'key': 'value'})
-
-        self.assertEqual(mock_post.call_count, 1)
-
-        expected_result = {'key': 'value'}
-        self.assertEqual(result, expected_result)
-
-    @patch('getpass.getpass', return_value='token')
-    @patch('src.juniper.requests.Session.get', return_value=MagicMock(status_code=200))
-    @patch('src.juniper.requests.Session.put')
-    def test_put(self, mock_put, mock_successful_login, input_api_token):
-        # Set up the mock to return a response with a valid JSON payload
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = '{"key": "value"}'
-        mock_put.return_value = mock_response
-
-        admin = Admin(mist_login_method='token')
-        self.assertIsNotNone(admin)
-
-        # Call the method being tested
-        result = admin.put('/some_endpoint', {'key': 'value'})
-
-        # Assert that the mock put method was called once
-        self.assertEqual(mock_put.call_count, 1)
-
-        # Assert that the method returns the expected result
-        self.assertIsNotNone(result)
-
-    @patch('src.juniper.Admin.get_ap_versions')
-    def test_ap_versions_handling(self, mock_get_ap_versions):
-        # Set up a valid AP_VERSIONS environment variable
-        valid_ap_versions = {"AP45": "0.12.27139", "AP32": "0.12.27139"}
-        mock_get_ap_versions.return_value = valid_ap_versions
-
-        # Test if juniper_script or Admin class handles valid AP_VERSIONS correctly
-        self.assertEqual(Admin.get_ap_versions(), valid_ap_versions)
-
-    @patch.dict('os.environ', {'AP_VERSIONS': 'Invalid JSON'})
-    def test_invalid_ap_versions_handling(self):
-        # Test with invalid AP_VERSIONS
-        with self.assertRaises(ValueError) as cm:
-            Admin.get_ap_versions()
-        self.assertEqual(str(cm.exception), 'Invalid AP_VERSIONS')
+    # @patch('src.juniper.Admin.get_ap_versions')
+    # def test_ap_versions_handling(self, mock_get_ap_versions):
+    #     # Set up a valid AP_VERSIONS environment variable
+    #     valid_ap_versions = {"AP45": "0.12.27139", "AP32": "0.12.27139"}
+    #     mock_get_ap_versions.return_value = valid_ap_versions
+    #
+    #     # Test if juniper_script or Admin class handles valid AP_VERSIONS correctly
+    #     self.assertEqual(Admin.get_ap_versions(), valid_ap_versions)
+    #
+    # @patch.dict('os.environ', {'AP_VERSIONS': 'Invalid JSON'})
+    # def test_invalid_ap_versions_handling(self):
+    #     # Test with invalid AP_VERSIONS
+    #     with self.assertRaises(ValueError) as cm:
+    #         Admin.get_ap_versions()
+    #     self.assertEqual(str(cm.exception), 'Invalid AP_VERSIONS')
 
 
 class TestCheckIfNeedToAppend(unittest.TestCase):
@@ -338,34 +240,6 @@ class TestCheckIfNeedToAppend(unittest.TestCase):
         result = check_if_we_need_to_append_gov_wifi_or_moj_wifi_site_groups(
             gov_wifi, moj_wifi, self.site_group_ids)
         self.assertEqual(result, [])
-
-
-class TestBuildPayLoadFunction(unittest.TestCase):
-    def setUp(self):
-        self.data = {'Site Name': 'TestSite', 'Site Address': '123 Main St',
-                     'gps': [1.23, 4.56], 'country_code': 'US', 'time_zone': 'UTC',
-                     'Enable GovWifi': 'true', 'Enable MoJWifi': 'false',
-                     'Wired NACS Radius Key': 'key1', 'GovWifi Radius Key': 'key2'}
-        self.rf_template_id = "rf_template_id",
-        self.network_template_id = "network_template_id",
-        self.site_group_ids = '{"moj_wifi": "foo","gov_wifi": "bar"}'
-
-    def test_something(self):
-        result = build_payload(self.data,
-                      self.rf_template_id,
-                      self.network_template_id,
-                      self.site_group_ids)
-
-
-        self.assertEqual(result[0], {'address': '123 Main St',
-                                       'country_code': 'US',
-                                       'latlng': {'lat': 1.23,'lng': 4.56},
-                                       'name': 'TestSite',
-                                       'networktemplate_id': ('network_template_id',),
-                                       'rftemplate_id': ('rf_template_id',),
-                                       'sitegroup_ids': [],
-                                       'timezone': 'UTC'})
-        print("h")
 
 
 

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -147,22 +147,6 @@ class TestJuniperScript(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), 'Please provide Mist org_id')
 
-    # @patch('src.juniper.Admin.get_ap_versions')
-    # def test_ap_versions_handling(self, mock_get_ap_versions):
-    #     # Set up a valid AP_VERSIONS environment variable
-    #     valid_ap_versions = {"AP45": "0.12.27139", "AP32": "0.12.27139"}
-    #     mock_get_ap_versions.return_value = valid_ap_versions
-    #
-    #     # Test if juniper_script or Admin class handles valid AP_VERSIONS correctly
-    #     self.assertEqual(Admin.get_ap_versions(), valid_ap_versions)
-    #
-    # @patch.dict('os.environ', {'AP_VERSIONS': 'Invalid JSON'})
-    # def test_invalid_ap_versions_handling(self):
-    #     # Test with invalid AP_VERSIONS
-    #     with self.assertRaises(ValueError) as cm:
-    #         Admin.get_ap_versions()
-    #     self.assertEqual(str(cm.exception), 'Invalid AP_VERSIONS')
-
 
 class TestPlanOfActionFunction(unittest.TestCase):
 

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -8,6 +8,7 @@ import os
 import pytest
 from parameterized import parameterized
 
+
 class TestJuniperScript(unittest.TestCase):
 
     @patch('src.juniper.plan_of_action')
@@ -71,7 +72,7 @@ class TestJuniperScript(unittest.TestCase):
     @parameterized.expand(
         ["3e824dd6-6b37-4cc7-90bb-97d744e91175",
          "9fd50080-520d-49ec-96a0-09f263fc8a05"
-    ])
+         ])
     @patch('builtins.input', return_value='y')
     def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_y_then_continue_to_run(self,
                                                                                                          production_org_id,
@@ -131,7 +132,8 @@ class TestJuniperScript(unittest.TestCase):
                            rf_template_id='46b87163-abd2-4b08-a67f-1ccecfcfd061',
                            network_template_id='46b87163-abd2-4b08-a67f-1ccecfcfd061',
                            mist_login_method=None,
-                           ap_versions={"AP45": "0.12.27139", "AP32": "0.12.27139"}
+                           ap_versions={"AP45": "0.12.27139",
+                                        "AP32": "0.12.27139"}
                            )
             actual_output = mock_stdout.getvalue()
         expected_message = "mist_login_method not defined. Defaulting to credentials"
@@ -144,9 +146,6 @@ class TestJuniperScript(unittest.TestCase):
             juniper_script([], org_id=None)
 
         self.assertEqual(str(cm.exception), 'Please provide Mist org_id')
-
-
-
 
     # @patch('src.juniper.Admin.get_ap_versions')
     # def test_ap_versions_handling(self, mock_get_ap_versions):
@@ -164,6 +163,7 @@ class TestJuniperScript(unittest.TestCase):
     #         Admin.get_ap_versions()
     #     self.assertEqual(str(cm.exception), 'Invalid AP_VERSIONS')
 
+
 class TestPlanOfActionFunction(unittest.TestCase):
 
     @patch("src.juniper.BuildPayload")
@@ -171,7 +171,8 @@ class TestPlanOfActionFunction(unittest.TestCase):
 
         # Mocking the payload processor
         mock_processor_instance = mock_payload_processor.return_value
-        mock_processor_instance.get_site_payload.return_value = {"hello": "test"}
+        mock_processor_instance.get_site_payload.return_value = {
+            "hello": "test"}
 
         with patch('builtins.input', return_value='Y'), patch('sys.exit') as mock_exit:
             plan_of_action(mock_processor_instance)
@@ -186,7 +187,8 @@ class TestPlanOfActionFunction(unittest.TestCase):
 
         # Mocking the payload processor
         mock_processor_instance = mock_payload_processor.return_value
-        mock_processor_instance.get_site_payload.return_value = {"hello": "test"}
+        mock_processor_instance.get_site_payload.return_value = {
+            "hello": "test"}
 
         with patch('builtins.input', return_value='N'), self.assertRaises(SystemExit) as cm:
             plan_of_action(mock_processor_instance)
@@ -198,7 +200,8 @@ class TestPlanOfActionFunction(unittest.TestCase):
 
         # Mocking the payload processor
         mock_processor_instance = mock_payload_processor.return_value
-        mock_processor_instance.get_site_payload.return_value = {"hello": "test"}
+        mock_processor_instance.get_site_payload.return_value = {
+            "hello": "test"}
 
         # Mocking the built-in input
         with patch('builtins.input', return_value='invalid_input'):

--- a/test/test_juniper.py
+++ b/test/test_juniper.py
@@ -107,27 +107,36 @@ class TestJuniperScript(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'Must define rf_template_id')
 
     @parameterized.expand(
-        "production_org_id", ["3e824dd6-6b37-4cc7-90bb-97d744e91175",
+        ["3e824dd6-6b37-4cc7-90bb-97d744e91175",
          "9fd50080-520d-49ec-96a0-09f263fc8a05"
     ])
     @patch('builtins.input', return_value='y')
-    def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_y_then_continue_to_run(self, user_input,
+    def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_y_then_continue_to_run(self,
                                                                                                          production_org_id,
+                                                                                                         user_input
                                                                                                          ):
-        print(production_org_id)
         result = warn_if_using_org_id_production(production_org_id)
         self.assertEqual('Continuing_with_run', result)
 
+    @parameterized.expand(
+        ["3e824dd6-6b37-4cc7-90bb-97d744e91175",
+         "9fd50080-520d-49ec-96a0-09f263fc8a05"
+         ])
     @patch('builtins.input', return_value='n')
-    def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_n_then_sys_exit(self, user_input):
-        production_org_id = '3e824dd6-6b37-4cc7-90bb-97d744e91175'
+    def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_n_then_sys_exit(self,
+                                                                                                  production_org_id,
+                                                                                                  user_input):
         with self.assertRaises(SystemExit):
             warn_if_using_org_id_production(production_org_id)
 
+    @parameterized.expand(
+        ["3e824dd6-6b37-4cc7-90bb-97d744e91175",
+         "9fd50080-520d-49ec-96a0-09f263fc8a05"
+         ])
     @patch('builtins.input', return_value='invalid')
     def test_given_production_org_id_when_user_prompted_for_input_and_user_inputs_invalid_then_raise_error(self,
+                                                                                                           production_org_id,
                                                                                                            user_input):
-        production_org_id = '3e824dd6-6b37-4cc7-90bb-97d744e91175'
         with self.assertRaises(ValueError) as cm:
             warn_if_using_org_id_production(production_org_id)
 

--- a/test/test_juniper_client.py
+++ b/test/test_juniper_client.py
@@ -11,7 +11,7 @@ class TestJuniperClient(unittest.TestCase):
     @patch('src.juniper_client.requests.Session.post', return_value=MagicMock(status_code=200))
     def test_login_successfully_via_username_and_password(self, mock_post, input_mfa, input_password):
         admin = JuniperClient(username='test@example.com',
-                      mist_login_method='credentials')
+                              mist_login_method='credentials')
         self.assertIsNotNone(admin)
 
         mock_post.assert_called_with(
@@ -25,7 +25,7 @@ class TestJuniperClient(unittest.TestCase):
             self, mock_post, mfa_input, password_input):
         with self.assertRaises(ValueError) as context:
             admin = JuniperClient(username='test@example.com',
-                          mist_login_method='credentials')
+                                  mist_login_method='credentials')
 
         # Check the expected part of the exception message
         expected_error_message = "Login was not successful:"
@@ -63,7 +63,6 @@ class TestJuniperClient(unittest.TestCase):
                                     )
 
         self.assertEqual(mock_get.call_count, 1)
-
 
     @patch('getpass.getpass', return_value='token')
     @patch('src.juniper_client.requests.Session.get', return_value=MagicMock(status_code=200))

--- a/test/test_juniper_client.py
+++ b/test/test_juniper_client.py
@@ -1,0 +1,108 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from src.juniper_client import JuniperClient
+
+
+class TestJuniperClient(unittest.TestCase):
+
+    # Mocking the input function to provide a static MFA code
+    @patch('getpass.getpass', return_value='password')
+    @patch('builtins.input', return_value='123456')
+    @patch('src.juniper_client.requests.Session.post', return_value=MagicMock(status_code=200))
+    def test_login_successfully_via_username_and_password(self, mock_post, input_mfa, input_password):
+        admin = JuniperClient(username='test@example.com',
+                      mist_login_method='credentials')
+        self.assertIsNotNone(admin)
+
+        mock_post.assert_called_with(
+            'https://api.eu.mist.com/api/v1/login/two_factor', data={'two_factor': '123456'})
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch('getpass.getpass', return_value='password')
+    @patch('builtins.input', return_value='123456')
+    @patch('src.juniper_client.requests.Session.post', return_value=MagicMock(status_code=400))
+    def test_given_valid_username_and_password_when_post_to_api_and_non_200_status_code_received_then_raise_error_to_user(
+            self, mock_post, mfa_input, password_input):
+        with self.assertRaises(ValueError) as context:
+            admin = JuniperClient(username='test@example.com',
+                          mist_login_method='credentials')
+
+        # Check the expected part of the exception message
+        expected_error_message = "Login was not successful:"
+        self.assertTrue(expected_error_message in str(context.exception))
+
+        # Ensure the post method is called with the correct parameters
+        mock_post.assert_called_with(
+            'https://api.eu.mist.com/api/v1/login/two_factor',
+            data={'two_factor': '123456'}
+        )
+
+        # Ensure the post method is called twice
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch('getpass.getpass', return_value='test_token')
+    @patch('src.juniper_client.requests.Session')
+    def test_given_valid_api_token_when_post_to_api_and_non_200_status_code_received_then_raise_error_to_user(self,
+                                                                                                              mock_session,
+                                                                                                              api_token):
+        mock_get = mock_session.return_value.get
+        mock_get.return_value = MagicMock(status_code=400)
+
+        with self.assertRaises(ValueError) as context:
+            admin = JuniperClient(mist_login_method='token')
+
+        # Check the expected part of the exception message
+        expected_error_message = "Login was not successful via token:"
+        self.assertTrue(expected_error_message in str(context.exception))
+
+        # Ensure the get method is called with the correct parameters
+        expected_url = 'https://api.eu.mist.com/api/v1/self/apitokens'
+        mock_get.assert_called_with(expected_url,
+                                    headers={'Content-Type': 'application/json',
+                                             'Authorization': 'Token test_token'}
+                                    )
+
+        self.assertEqual(mock_get.call_count, 1)
+
+
+    @patch('getpass.getpass', return_value='token')
+    @patch('src.juniper_client.requests.Session.get', return_value=MagicMock(status_code=200))
+    @patch('src.juniper_client.requests.Session.post')
+    def test_post(self, mock_post, mock_successful_login, input_api_token):
+        # Set up the mock to return a response with a valid JSON payload
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"key": "value"}'
+        mock_post.return_value = mock_response
+
+        admin = JuniperClient(mist_login_method='token')
+        self.assertIsNotNone(admin)
+
+        result = admin.post('/some_endpoint', {'key': 'value'})
+
+        self.assertEqual(mock_post.call_count, 1)
+
+        expected_result = {'key': 'value'}
+        self.assertEqual(result, expected_result)
+
+    @patch('getpass.getpass', return_value='token')
+    @patch('src.juniper_client.requests.Session.get', return_value=MagicMock(status_code=200))
+    @patch('src.juniper_client.requests.Session.put')
+    def test_put(self, mock_put, mock_successful_login, input_api_token):
+        # Set up the mock to return a response with a valid JSON payload
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"key": "value"}'
+        mock_put.return_value = mock_response
+
+        admin = JuniperClient(mist_login_method='token')
+        self.assertIsNotNone(admin)
+
+        # Call the method being tested
+        result = admin.put('/some_endpoint', {'key': 'value'})
+
+        # Assert that the mock put method was called once
+        self.assertEqual(mock_put.call_count, 1)
+
+        # Assert that the method returns the expected result
+        self.assertIsNotNone(result)


### PR DESCRIPTION
Added new requirements:

- On the site settings (on Rogue AP section), there’s GovWifi whitelisted. On prisons we shouldn’t have any GovWifi related config and therefore:   "whitelisted_ssids": [ "GovWifi" ] section should be empty. I think you had a good idea how to implement this: if the site.csv file doesn’t have GovWifi shared secret column, this would keep whitelisted_ssids empty.
- Site variable “site_specific_radius_wired_nacs_secret” is not actually required. This was for switches and the prisons are using Cisco switches, they wouldn’t get this configuration from Juniper Mist dashboard. I guess this could be done by removing the column from site.csv file similar than GovWifi secret.

Refactor:

- Made unit tests better
- Renamed Admin to JuniperClient to be more reflective of operation and moved into its own module
- Created a new module named BuildPayload that takes responsibility for building the json output